### PR TITLE
Extended unit tests and modifications to NotifierBackgroundService

### DIFF
--- a/Source/RocketNotify.BackgroundServices/NotifierBackgroundService.cs
+++ b/Source/RocketNotify.BackgroundServices/NotifierBackgroundService.cs
@@ -82,7 +82,7 @@
 
             try
             {
-                await _telegramClient.Initialize().ConfigureAwait(false);
+                await _telegramClient.InitializeAsync().ConfigureAwait(false);
                 await _rocketChatClient.InitializeAsync().ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/Source/RocketNotify.BackgroundServices/NotifierBackgroundService.cs
+++ b/Source/RocketNotify.BackgroundServices/NotifierBackgroundService.cs
@@ -9,14 +9,24 @@
 
     using RocketNotify.BackgroundServices.Settings;
     using RocketNotify.ChatClient;
+    using RocketNotify.ChatClient.Exceptions;
+    using RocketNotify.Subscription.Model;
     using RocketNotify.Subscription.Services;
     using RocketNotify.TelegramBot.Client;
+
+    using Telegram.Bot.Exceptions;
 
     /// <summary>
     /// Rocket.Chat message notification background service.
     /// </summary>
     public class NotifierBackgroundService : BackgroundService
     {
+        /// <summary>
+        /// The maximum number of Rocket.Chat or Telegram errors.
+        /// When this number is reached, execution will stop.
+        /// </summary>
+        private const int MaxErrorsCount = 10;
+
         /// <summary>
         /// Client used for sending Telegram messages.
         /// </summary>
@@ -51,6 +61,16 @@
         /// The last received message timestamp.
         /// </summary>
         private DateTime _lastMessageTimeStamp = default;
+
+        /// <summary>
+        /// Current Rocket.Chat client errors count.
+        /// </summary>
+        private int _chatClientErrorsCount;
+
+        /// <summary>
+        /// Current Telegram errors count.
+        /// </summary>
+        private int _telegramErrorsCount;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NotifierBackgroundService"/> class.
@@ -91,12 +111,18 @@
                 return;
             }
 
-            _lastMessageTimeStamp = await _rocketChatClient.GetLastMessageTimeStampAsync().ConfigureAwait(false);
+            _lastMessageTimeStamp = await GetLastMessageTimeStampAsync().ConfigureAwait(false);
             while (!stoppingToken.IsCancellationRequested)
             {
+                if (_chatClientErrorsCount >= MaxErrorsCount || _telegramErrorsCount >= MaxErrorsCount)
+                {
+                    _logger.LogCritical("Maximum number of errors reached, execution stopped");
+                    return;
+                }
+
                 await Task.Delay(_delayTime, stoppingToken).ConfigureAwait(false);
 
-                var newMessageTimeStamp = await _rocketChatClient.GetLastMessageTimeStampAsync().ConfigureAwait(false);
+                var newMessageTimeStamp = await GetLastMessageTimeStampAsync().ConfigureAwait(false);
                 if (newMessageTimeStamp > _lastMessageTimeStamp)
                 {
                     _lastMessageTimeStamp = newMessageTimeStamp;
@@ -114,8 +140,59 @@
         private async Task NotifySubscribersAsync()
         {
             var subscribers = await _subscriptionService.GetAllSubscriptionsAsync().ConfigureAwait(false);
-            foreach (var subs in subscribers)
-                await _telegramClient.SendMessageAsync(subs.ChatId, "New Rocket.Chat message received").ConfigureAwait(false);
+            foreach (var sub in subscribers)
+                await NotifyAsync(sub).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the latest group chat message timestamp.
+        /// </summary>
+        /// <returns>The latest group chat message timestamp.</returns>
+        private async Task<DateTime> GetLastMessageTimeStampAsync()
+        {
+            try
+            {
+                var lastMessageTime = await _rocketChatClient.GetLastMessageTimeStampAsync().ConfigureAwait(false);
+                _chatClientErrorsCount = 0;
+
+                return lastMessageTime;
+            }
+            catch (RocketChatApiException ex)
+            {
+                _chatClientErrorsCount++;
+                _logger.LogError(ex, $"Error occurred while obtaining time of the latest message in Rocket.Chat group ({_chatClientErrorsCount} / {MaxErrorsCount})");
+
+                return default;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogCritical(ex, "Critical error occurred");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Sends notification to the subscriber.
+        /// </summary>
+        /// <param name="subscriber">Subscriber info.</param>
+        /// <returns>A task that represents the subscriber notification process.</returns>
+        private async Task NotifyAsync(Subscriber subscriber)
+        {
+            try
+            {
+                await _telegramClient.SendMessageAsync(subscriber.ChatId, "New Rocket.Chat message received").ConfigureAwait(false);
+                _telegramErrorsCount = 0;
+            }
+            catch (ApiRequestException ex)
+            {
+                _telegramErrorsCount++;
+                _logger.LogError(ex, $"Error occurred while sending notification to {subscriber.ChatId} ({_telegramErrorsCount} / {MaxErrorsCount})");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogCritical(ex, "Critical error occurred");
+                throw;
+            }
         }
     }
 }

--- a/Source/RocketNotify.BackgroundServices/TelegramBotBackgroundService.cs
+++ b/Source/RocketNotify.BackgroundServices/TelegramBotBackgroundService.cs
@@ -40,7 +40,7 @@
         {
             try
             {
-                await _telegramBot.Initialize().ConfigureAwait(false);
+                await _telegramBot.InitializeAsync().ConfigureAwait(false);
                 _telegramBot.StartPolling(cancellationToken);
             }
             catch (Exception ex)

--- a/Source/RocketNotify.DependencyInjection/TelegramBotServiceRegistration.cs
+++ b/Source/RocketNotify.DependencyInjection/TelegramBotServiceRegistration.cs
@@ -7,6 +7,8 @@
 
     using RocketNotify.TelegramBot.Client;
     using RocketNotify.TelegramBot.Client.Factory;
+    using RocketNotify.TelegramBot.Filtration;
+    using RocketNotify.TelegramBot.Filtration.Factory;
     using RocketNotify.TelegramBot.MessageProcessing;
     using RocketNotify.TelegramBot.MessageProcessing.Commands;
     using RocketNotify.TelegramBot.MessageProcessing.Help;
@@ -15,8 +17,6 @@
     using RocketNotify.TelegramBot.MessageProcessing.Unsubscribe;
     using RocketNotify.TelegramBot.MessageProcessing.Unsupported;
     using RocketNotify.TelegramBot.Messages;
-    using RocketNotify.TelegramBot.Messages.Filtration;
-    using RocketNotify.TelegramBot.Messages.Filtration.Factory;
     using RocketNotify.TelegramBot.Settings;
 
     /// <summary>

--- a/Source/RocketNotify.TelegramBot/Client/IInitializableTelegramClient.cs
+++ b/Source/RocketNotify.TelegramBot/Client/IInitializableTelegramClient.cs
@@ -11,6 +11,6 @@
         /// Initializes a client.
         /// </summary>
         /// <returns>A task that represents an initialization process.</returns>
-        Task Initialize();
+        Task InitializeAsync();
     }
 }

--- a/Source/RocketNotify.TelegramBot/Client/TelegramBotPollingClient.cs
+++ b/Source/RocketNotify.TelegramBot/Client/TelegramBotPollingClient.cs
@@ -44,7 +44,7 @@
         }
 
         /// <inheritdoc />
-        public async Task Initialize()
+        public async Task InitializeAsync()
         {
             lock (_botClientFactory)
             {

--- a/Source/RocketNotify.TelegramBot/Filtration/BotMentionMessageFilter.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/BotMentionMessageFilter.cs
@@ -42,10 +42,7 @@
 
             var botUserName = _settingProvider.GetBotUserName();
             if (string.IsNullOrEmpty(botUserName))
-            {
-                // TODO Logging
                 throw new InvalidOperationException("The bot name must be provided for it to accept commands from group chats");
-            }
 
             var entities = message.GetEntities();
             var mentions = entities.Where(entity => entity.Type == MessageEntityType.Mention);

--- a/Source/RocketNotify.TelegramBot/Filtration/BotMentionMessageFilter.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/BotMentionMessageFilter.cs
@@ -1,8 +1,9 @@
-﻿namespace RocketNotify.TelegramBot.Messages.Filtration
+﻿namespace RocketNotify.TelegramBot.Filtration
 {
     using System;
     using System.Linq;
 
+    using RocketNotify.TelegramBot.Messages;
     using RocketNotify.TelegramBot.Settings;
 
     using Telegram.Bot.Types;

--- a/Source/RocketNotify.TelegramBot/Filtration/ChatTypeMessageFilter.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/ChatTypeMessageFilter.cs
@@ -1,11 +1,12 @@
-﻿namespace RocketNotify.TelegramBot.Messages.Filtration
+﻿namespace RocketNotify.TelegramBot.Filtration
 {
     using Telegram.Bot.Types;
+    using Telegram.Bot.Types.Enums;
 
     /// <summary>
-    /// Filters a message based on its type.
+    /// Filters a message based on the type of chat it came from.
     /// </summary>
-    public class MessageTypeMessageFilter : IChainedMessageFilter
+    public class ChatTypeMessageFilter : IChainedMessageFilter
     {
         /// <summary>
         /// Next message filter.
@@ -15,7 +16,7 @@
         /// <inheritdoc/>
         public bool Filter(Message message)
         {
-            if (message.Type != Telegram.Bot.Types.Enums.MessageType.Text)
+            if (message.Chat.Type == ChatType.Supergroup || message.Chat.Type == ChatType.Channel)
                 return false;
 
             return _nextFilter.Filter(message);

--- a/Source/RocketNotify.TelegramBot/Filtration/ContainsCommandMessageFilter.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/ContainsCommandMessageFilter.cs
@@ -1,4 +1,4 @@
-﻿namespace RocketNotify.TelegramBot.Messages.Filtration
+﻿namespace RocketNotify.TelegramBot.Filtration
 {
     using System.Linq;
 

--- a/Source/RocketNotify.TelegramBot/Filtration/Factory/IMessageFilterFactory.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/Factory/IMessageFilterFactory.cs
@@ -1,5 +1,7 @@
-﻿namespace RocketNotify.TelegramBot.Messages.Filtration.Factory
+﻿namespace RocketNotify.TelegramBot.Filtration.Factory
 {
+    using RocketNotify.TelegramBot.Filtration;
+
     /// <summary>
     /// Provides functionality for obtaining message filtration units.
     /// </summary>

--- a/Source/RocketNotify.TelegramBot/Filtration/Factory/MessageFilterFactory.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/Factory/MessageFilterFactory.cs
@@ -1,8 +1,10 @@
-﻿namespace RocketNotify.TelegramBot.Messages.Filtration.Factory
+﻿namespace RocketNotify.TelegramBot.Filtration.Factory
 {
     using System;
     using System.Collections.Generic;
     using System.Linq;
+
+    using RocketNotify.TelegramBot.Filtration;
 
     /// <inheritdoc />
     public class MessageFilterFactory : IMessageFilterFactory

--- a/Source/RocketNotify.TelegramBot/Filtration/IChainedMessageFilter.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/IChainedMessageFilter.cs
@@ -1,4 +1,4 @@
-﻿namespace RocketNotify.TelegramBot.Messages.Filtration
+﻿namespace RocketNotify.TelegramBot.Filtration
 {
     /// <summary>
     /// An interface that provides operations for configuring the message filters chain.

--- a/Source/RocketNotify.TelegramBot/Filtration/IMessageFilter.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/IMessageFilter.cs
@@ -1,4 +1,4 @@
-﻿namespace RocketNotify.TelegramBot.Messages.Filtration
+﻿namespace RocketNotify.TelegramBot.Filtration
 {
     using Telegram.Bot.Types;
 

--- a/Source/RocketNotify.TelegramBot/Filtration/MessageTypeMessageFilter.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/MessageTypeMessageFilter.cs
@@ -1,12 +1,11 @@
-﻿namespace RocketNotify.TelegramBot.Messages.Filtration
+﻿namespace RocketNotify.TelegramBot.Filtration
 {
     using Telegram.Bot.Types;
-    using Telegram.Bot.Types.Enums;
 
     /// <summary>
-    /// Filters a message based on the type of chat it came from.
+    /// Filters a message based on its type.
     /// </summary>
-    public class ChatTypeMessageFilter : IChainedMessageFilter
+    public class MessageTypeMessageFilter : IChainedMessageFilter
     {
         /// <summary>
         /// Next message filter.
@@ -16,7 +15,7 @@
         /// <inheritdoc/>
         public bool Filter(Message message)
         {
-            if (message.Chat.Type == ChatType.Supergroup || message.Chat.Type == ChatType.Channel)
+            if (message.Type != Telegram.Bot.Types.Enums.MessageType.Text)
                 return false;
 
             return _nextFilter.Filter(message);

--- a/Source/RocketNotify.TelegramBot/Filtration/RelevantMessageFilter.cs
+++ b/Source/RocketNotify.TelegramBot/Filtration/RelevantMessageFilter.cs
@@ -1,4 +1,4 @@
-﻿namespace RocketNotify.TelegramBot.Messages.Filtration
+﻿namespace RocketNotify.TelegramBot.Filtration
 {
     using RocketNotify.TelegramBot.MessageProcessing;
     using RocketNotify.TelegramBot.MessageProcessing.Model;

--- a/Source/RocketNotify.TelegramBot/MessageProcessing/IMessageProcessorStorage.cs
+++ b/Source/RocketNotify.TelegramBot/MessageProcessing/IMessageProcessorStorage.cs
@@ -8,6 +8,11 @@
     public interface IMessageProcessorStorage
     {
         /// <summary>
+        /// Gets the number of processors stored.
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
         /// Adds the message processor to the storage.
         /// </summary>
         /// <param name="processor">The processor to store.</param>

--- a/Source/RocketNotify.TelegramBot/MessageProcessing/MessageProcessorStorage.cs
+++ b/Source/RocketNotify.TelegramBot/MessageProcessing/MessageProcessorStorage.cs
@@ -16,6 +16,9 @@
         private readonly List<IMessageProcessor> _processors = new List<IMessageProcessor>();
 
         /// <inheritdoc/>
+        public int Count => _processors.Count;
+
+        /// <inheritdoc/>
         public IMessageProcessor GetExisting(BotMessage message)
         {
             var existing = _processors.FirstOrDefault(p => p.IsRelevant(message));

--- a/Source/RocketNotify.TelegramBot/MessageProcessing/Model/MessageConverter.cs
+++ b/Source/RocketNotify.TelegramBot/MessageProcessing/Model/MessageConverter.cs
@@ -9,14 +9,14 @@
     /// <summary>
     /// Provides functionality for conversion between the <see cref="Telegram.Bot.Types.Message"/> and <see cref="BotMessage"/> classes.
     /// </summary>
-    internal static class MessageConverter
+    public static class MessageConverter
     {
         /// <summary>
         /// Converts an instance of the <see cref="Telegram.Bot.Types.Message"/> class to an instance of the <see cref="BotMessage"/> class.
         /// </summary>
         /// <param name="message">The <see cref="Telegram.Bot.Types.Message"/> instance being converted.</param>
         /// <returns>An instance of the <see cref="BotMessage"/> class.</returns>
-        internal static BotMessage Convert(Message message)
+        public static BotMessage Convert(Message message)
         {
             var msg = new BotMessage
             {

--- a/Source/RocketNotify.TelegramBot/Messages/BotMessageHandler.cs
+++ b/Source/RocketNotify.TelegramBot/Messages/BotMessageHandler.cs
@@ -5,9 +5,9 @@
 
     using Microsoft.Extensions.Logging;
 
+    using RocketNotify.TelegramBot.Filtration.Factory;
     using RocketNotify.TelegramBot.MessageProcessing;
     using RocketNotify.TelegramBot.MessageProcessing.Model;
-    using RocketNotify.TelegramBot.Messages.Filtration.Factory;
 
     using Telegram.Bot.Types;
 

--- a/Source/RocketNotifyBot.sln
+++ b/Source/RocketNotifyBot.sln
@@ -36,6 +36,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TelegramBotRunner", "Telegr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RocketNotify.Logging", "RocketNotify.Logging\RocketNotify.Logging.csproj", "{2FB5FCD4-F019-49FD-96EF-AC4DD12869BE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RocketNotify.BackgroundServices.Tests", "Tests\RocketNotify.BackgroundServices.Tests\RocketNotify.BackgroundServices.Tests.csproj", "{352CB6B0-9FA9-41C7-90E3-A32C79DF50CA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,10 @@ Global
 		{2FB5FCD4-F019-49FD-96EF-AC4DD12869BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FB5FCD4-F019-49FD-96EF-AC4DD12869BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FB5FCD4-F019-49FD-96EF-AC4DD12869BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{352CB6B0-9FA9-41C7-90E3-A32C79DF50CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{352CB6B0-9FA9-41C7-90E3-A32C79DF50CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{352CB6B0-9FA9-41C7-90E3-A32C79DF50CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{352CB6B0-9FA9-41C7-90E3-A32C79DF50CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,6 +100,7 @@ Global
 		{CE6E6F52-47B5-4ED7-B86E-5A5BBAF10CA4} = {9ABF34D0-587B-4D21-8A3D-77AF9DDD60D0}
 		{AF32A6A7-F1C1-46DE-8B49-5A461E22D21C} = {9ABF34D0-587B-4D21-8A3D-77AF9DDD60D0}
 		{A73C160D-387E-49D6-ADF5-CF3EAAED76FB} = {9ABF34D0-587B-4D21-8A3D-77AF9DDD60D0}
+		{352CB6B0-9FA9-41C7-90E3-A32C79DF50CA} = {9ABF34D0-587B-4D21-8A3D-77AF9DDD60D0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B5F15EBA-DC84-4519-A68C-8CA6519B3E28}

--- a/Source/Tests/RocketNotify.BackgroundServices.Tests/NotifierBackgroundServiceTests.cs
+++ b/Source/Tests/RocketNotify.BackgroundServices.Tests/NotifierBackgroundServiceTests.cs
@@ -1,0 +1,112 @@
+﻿namespace RocketNotify.BackgroundServices.Tests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Microsoft.Extensions.Logging;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.BackgroundServices.Settings;
+    using RocketNotify.ChatClient;
+    using RocketNotify.Subscription.Model;
+    using RocketNotify.Subscription.Services;
+    using RocketNotify.TelegramBot.Client;
+
+    [TestFixture]
+    public class NotifierBackgroundServiceTests
+    {
+        private Mock<ITelegramMessageSender> _messageSender;
+
+        private Mock<IRocketChatClient> _rocketChatClient;
+
+        private Mock<ISubscriptionService> _subscriptionService;
+
+        private Mock<IServicesSettingsProvider> _settingsProvider;
+
+        private NotifierBackgroundService _backgroundService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _messageSender = new Mock<ITelegramMessageSender>();
+            _rocketChatClient = new Mock<IRocketChatClient>();
+            _subscriptionService = new Mock<ISubscriptionService>();
+            _settingsProvider = new Mock<IServicesSettingsProvider>();
+
+            var logger = new Mock<ILogger<NotifierBackgroundService>>();
+            _backgroundService = new NotifierBackgroundService(
+                _messageSender.Object,
+                _rocketChatClient.Object,
+                _subscriptionService.Object,
+                logger.Object,
+                _settingsProvider.Object);
+        }
+
+        [Test]
+        public async Task StartAsync_TelegramInitializationError_ShouldReturn()
+        {
+            _messageSender.Setup(x => x.InitializeAsync()).ThrowsAsync(new InvalidOperationException());
+
+            await _backgroundService.StartAsync(CancellationToken.None).ConfigureAwait(false);
+            await Task.Delay(5).ConfigureAwait(false);
+            await _backgroundService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+            _messageSender.Verify(x => x.InitializeAsync(), Times.Once);
+            _rocketChatClient.Verify(x => x.InitializeAsync(), Times.Never);
+            _rocketChatClient.Verify(x => x.GetLastMessageTimeStampAsync(), Times.Never);
+        }
+
+        [Test]
+        public async Task StartAsync_ChatClientInitializationError_ShouldReturn()
+        {
+            _rocketChatClient.Setup(x => x.InitializeAsync()).ThrowsAsync(new InvalidOperationException());
+
+            await _backgroundService.StartAsync(CancellationToken.None).ConfigureAwait(false);
+            await Task.Delay(5).ConfigureAwait(false);
+            await _backgroundService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+            _messageSender.Verify(x => x.InitializeAsync(), Times.Once);
+            _rocketChatClient.Verify(x => x.InitializeAsync(), Times.Once);
+            _rocketChatClient.Verify(x => x.GetLastMessageTimeStampAsync(), Times.Never);
+        }
+
+        [Test]
+        public async Task StartAsync_CancelledAfterStart_ShouldReturn()
+        {
+            _settingsProvider.Setup(x => x.GetMessageCheckInterval()).Returns(TimeSpan.FromSeconds(6));
+
+            using var cts = new CancellationTokenSource(1);
+            await _backgroundService.StartAsync(cts.Token).ConfigureAwait(false);
+            await Task.Delay(5).ConfigureAwait(false);
+            await _backgroundService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+            _messageSender.Verify(x => x.InitializeAsync(), Times.Once);
+            _rocketChatClient.Verify(x => x.InitializeAsync(), Times.Once);
+            _rocketChatClient.Verify(x => x.GetLastMessageTimeStampAsync(), Times.Once);
+        }
+
+        [Test]
+        public async Task StartAsync_FoundNewMessage_ShouldNotify()
+        {
+            var subscriber = new Subscriber { ChatId = 1 };
+            var currentDateTime = DateTime.Now;
+
+            _settingsProvider.Setup(x => x.GetMessageCheckInterval()).Returns(TimeSpan.FromMilliseconds(1));
+            _subscriptionService.Setup(x => x.GetAllSubscriptionsAsync()).ReturnsAsync(new[] { subscriber });
+
+            var counter = 0;
+            _rocketChatClient.Setup(x => x.GetLastMessageTimeStampAsync()).ReturnsAsync(() => ++counter < 3 ? default : currentDateTime);
+
+            await _backgroundService.StartAsync(CancellationToken.None).ConfigureAwait(false);
+            await Task.Delay(30).ConfigureAwait(false);
+            await _backgroundService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+            _rocketChatClient.Verify(x => x.GetLastMessageTimeStampAsync(), Times.AtLeast(3));
+            _messageSender.Verify(x => x.SendMessageAsync(subscriber.ChatId, It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.BackgroundServices.Tests/RocketNotify.BackgroundServices.Tests.csproj
+++ b/Source/Tests/RocketNotify.BackgroundServices.Tests/RocketNotify.BackgroundServices.Tests.csproj
@@ -20,11 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\RocketNotify.TelegramBot\RocketNotify.TelegramBot.csproj" />
+    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
+    <ProjectReference Include="..\..\RocketNotify.BackgroundServices\RocketNotify.BackgroundServices.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Source/Tests/RocketNotify.BackgroundServices.Tests/Settings/ServicesSettingsProviderTests.cs
+++ b/Source/Tests/RocketNotify.BackgroundServices.Tests/Settings/ServicesSettingsProviderTests.cs
@@ -1,0 +1,63 @@
+﻿namespace RocketNotify.BackgroundServices.Tests.Settings
+{
+    using System;
+
+    using Microsoft.Extensions.Configuration;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.BackgroundServices.Settings;
+
+    [TestFixture]
+    public class ServicesSettingsProviderTests
+    {
+        private TimeSpan _defaultInterval = TimeSpan.FromSeconds(6);
+
+        private Mock<IConfiguration> _configurationMock;
+
+        private ServicesSettingsProvider _settingsProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _configurationMock = new Mock<IConfiguration>();
+            _settingsProvider = new ServicesSettingsProvider(_configurationMock.Object);
+        }
+
+        [Test]
+        public void GetMessageCheckInterval_NoSection_ShouldReturnDefaultValue()
+        {
+            var actual = _settingsProvider.GetMessageCheckInterval();
+            Assert.AreEqual(_defaultInterval, actual);
+        }
+
+        [Test]
+        public void GetMessageCheckInterval_InvalidFormat_ShouldReturnDefaultValue()
+        {
+            SetUpConfiguration("Notifications", "MessageCheckIntervalSec", "q");
+
+            var actual = _settingsProvider.GetMessageCheckInterval();
+            Assert.AreEqual(_defaultInterval, actual);
+        }
+
+        [Test]
+        public void GetMessageCheckInterval_ValidInterval_ShouldReturnValue()
+        {
+            var expected = TimeSpan.FromSeconds(30);
+            SetUpConfiguration("Notifications", "MessageCheckIntervalSec", "30");
+
+            var actual = _settingsProvider.GetMessageCheckInterval();
+            Assert.AreEqual(expected, actual);
+        }
+
+        private void SetUpConfiguration(string sectionName, string key, string value)
+        {
+            var sectionMock = new Mock<IConfigurationSection>();
+            sectionMock.Setup(x => x[key]).Returns(value);
+
+            _configurationMock.Setup(x => x.GetSection(sectionName)).Returns(sectionMock.Object);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Client/TelegramBotPollingClientTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Client/TelegramBotPollingClientTests.cs
@@ -60,7 +60,7 @@
         [Test]
         public async Task StartPolling_HasClient_ShouldStartReceiving()
         {
-            await _client.Initialize().ConfigureAwait(false);
+            await _client.InitializeAsync().ConfigureAwait(false);
             _client.StartPolling(CancellationToken.None);
 
             _botClientMock.Verify(x => x.StartReceiving(null, CancellationToken.None), Times.Once);
@@ -77,7 +77,7 @@
         {
             _botClientMock.Setup(x => x.IsReceiving).Returns(true);
 
-            await _client.Initialize().ConfigureAwait(false);
+            await _client.InitializeAsync().ConfigureAwait(false);
             _client.StopPolling();
 
             _botClientMock.Verify(x => x.StopReceiving(), Times.Once);
@@ -97,7 +97,7 @@
             var expectedText = "Message Text";
             var cancellationToken = CancellationToken.None;
 
-            await _client.Initialize().ConfigureAwait(false);
+            await _client.InitializeAsync().ConfigureAwait(false);
             _client.StartPolling(cancellationToken);
             var sentMessageId = await _client.SendMessageAsync(chatId, expectedText).ConfigureAwait(false);
 

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Client/TelegramBotPollingClientTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Client/TelegramBotPollingClientTests.cs
@@ -15,6 +15,7 @@
     using Telegram.Bot;
     using Telegram.Bot.Types;
     using Telegram.Bot.Types.Enums;
+    using Telegram.Bot.Types.ReplyMarkups;
 
     [TestFixture]
     public class TelegramBotPollingClientTests
@@ -33,6 +34,16 @@
             _messageHandlerMock = new Mock<IBotMessageHandler>();
             _botClientMock = new Mock<ITelegramBotClient>();
             _botClientMock.Setup(x => x.TestApiAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            _botClientMock.Setup(x => x.SendTextMessageAsync(
+                It.IsAny<ChatId>(),
+                It.IsAny<string>(),
+                It.IsAny<ParseMode>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<int>(),
+                It.IsAny<IReplyMarkup>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Message { MessageId = 1 });
 
             _botClientFactoryMock = new Mock<ITelegramBotClientFactory>();
             _botClientFactoryMock.Setup(x => x.GetClient()).Returns(_botClientMock.Object);
@@ -75,7 +86,7 @@
         [Test]
         public void SendMessageAsync_NoClient_ShouldThrowException()
         {
-            Assert.Throws<InvalidOperationException>(() => _client.SendMessageAsync(123456, string.Empty));
+            Assert.ThrowsAsync<InvalidOperationException>(() => _client.SendMessageAsync(123456, string.Empty));
         }
 
         [Test]
@@ -88,8 +99,9 @@
 
             await _client.Initialize().ConfigureAwait(false);
             _client.StartPolling(cancellationToken);
-            await _client.SendMessageAsync(chatId, expectedText).ConfigureAwait(false);
+            var sentMessageId = await _client.SendMessageAsync(chatId, expectedText).ConfigureAwait(false);
 
+            Assert.AreEqual(1, sentMessageId);
             _botClientMock.Verify(x => x.SendTextMessageAsync(It.IsAny<ChatId>(), expectedText, ParseMode.Default, false, false, 0, null, cancellationToken), Times.Once);
         }
     }

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/BotMentionMessageFilterTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/BotMentionMessageFilterTests.cs
@@ -1,0 +1,104 @@
+﻿namespace RocketNotify.TelegramBot.Tests.Filtration
+{
+    using System;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Filtration;
+    using RocketNotify.TelegramBot.Settings;
+
+    using Telegram.Bot.Types;
+    using Telegram.Bot.Types.Enums;
+
+    [TestFixture]
+    public class BotMentionMessageFilterTests
+    {
+        private Mock<IBotSettingsProvider> _settingsProvider;
+
+        private Mock<IMessageFilter> _nextFilter;
+
+        private BotMentionMessageFilter _filter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _settingsProvider = new Mock<IBotSettingsProvider>();
+            _nextFilter = new Mock<IMessageFilter>();
+            _nextFilter.Setup(x => x.Filter(It.IsAny<Message>())).Returns(true);
+
+            _filter = new BotMentionMessageFilter(_settingsProvider.Object);
+            _filter.SetNextFilter(_nextFilter.Object);
+        }
+
+        [Test]
+        public void Filter_NoBotName_ShouldThrowException()
+        {
+            var message = new Message { Chat = new Chat { Type = ChatType.Group } };
+            Assert.Throws<InvalidOperationException>(() => _filter.Filter(message));
+        }
+
+        [Test]
+        public void Filter_ChatIsPrivate_ShouldInvokeNextFilter()
+        {
+            var message = new Message { Chat = new Chat { Type = ChatType.Private } };
+            var actual = _filter.Filter(message);
+
+            Assert.True(actual);
+            _nextFilter.Verify(x => x.Filter(message), Times.Once);
+        }
+
+        [Test]
+        public void Filter_MessageContainsMention_ShouldInvokeNextFilter()
+        {
+            _settingsProvider.Setup(x => x.GetBotUserName()).Returns("@test_bot_name");
+
+            var message = new Message
+            {
+                Chat = new Chat { Type = ChatType.Group },
+                Text = "@test_bot_name",
+                Entities = new MessageEntity[]
+                {
+                    new MessageEntity { Type = MessageEntityType.Mention, Offset = 0, Length = 14 }
+                }
+            };
+            var actual = _filter.Filter(message);
+
+            Assert.True(actual);
+            _nextFilter.Verify(x => x.Filter(message), Times.Once);
+        }
+
+        [Test]
+        public void Filter_MessageContainsCommandWithMention_ShouldInvokeNextFilter()
+        {
+            _settingsProvider.Setup(x => x.GetBotUserName()).Returns("@test_bot_name");
+
+            var message = new Message
+            {
+                Chat = new Chat { Type = ChatType.Group },
+                Text = "/start@test_bot_name",
+                Entities = new MessageEntity[]
+                {
+                    new MessageEntity { Type = MessageEntityType.BotCommand, Offset = 0, Length = 20 }
+                }
+            };
+            var actual = _filter.Filter(message);
+
+            Assert.True(actual);
+            _nextFilter.Verify(x => x.Filter(message), Times.Once);
+        }
+
+        [Test]
+        public void Filter_MessageIsGroupAndWithoutMention_ShouldReturnFalse()
+        {
+            _settingsProvider.Setup(x => x.GetBotUserName()).Returns("@test_bot_name");
+
+            var message = new Message { Chat = new Chat { Type = ChatType.Group } };
+            var actual = _filter.Filter(message);
+
+            Assert.False(actual);
+            _nextFilter.Verify(x => x.Filter(It.IsAny<Message>()), Times.Never);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/ChatTypeMessageFilterTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/ChatTypeMessageFilterTests.cs
@@ -1,0 +1,51 @@
+﻿namespace RocketNotify.TelegramBot.Tests.Filtration
+{
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Filtration;
+
+    using Telegram.Bot.Types;
+    using Telegram.Bot.Types.Enums;
+
+    [TestFixture]
+    public class ChatTypeMessageFilterTests
+    {
+        private Mock<IMessageFilter> _nextFilter;
+
+        private ChatTypeMessageFilter _filter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _nextFilter = new Mock<IMessageFilter>();
+            _nextFilter.Setup(x => x.Filter(It.IsAny<Message>())).Returns(true);
+
+            _filter = new ChatTypeMessageFilter();
+            _filter.SetNextFilter(_nextFilter.Object);
+        }
+
+        [TestCase(ChatType.Supergroup)]
+        [TestCase(ChatType.Channel)]
+        public void Filter_SupergroupOrChannel_ShouldReturnFalse(ChatType chatType)
+        {
+            var message = new Message { Chat = new Chat { Type = chatType } };
+            var actual = _filter.Filter(message);
+
+            Assert.False(actual);
+            _nextFilter.Verify(x => x.Filter(It.IsAny<Message>()), Times.Never);
+        }
+
+        [TestCase(ChatType.Group)]
+        [TestCase(ChatType.Private)]
+        public void Filter_PrivateOrGroup_ShouldInvokeNextFilter(ChatType chatType)
+        {
+            var message = new Message { Chat = new Chat { Type = chatType } };
+            var actual = _filter.Filter(message);
+
+            Assert.True(actual);
+            _nextFilter.Verify(x => x.Filter(message), Times.Once);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/ContainsCommandMessageFilterTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/ContainsCommandMessageFilterTests.cs
@@ -1,0 +1,47 @@
+﻿namespace RocketNotify.TelegramBot.Tests.Filtration
+{
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Filtration;
+
+    using Telegram.Bot.Types;
+    using Telegram.Bot.Types.Enums;
+
+    [TestFixture]
+    public class ContainsCommandMessageFilterTests
+    {
+        private ContainsCommandMessageFilter _filter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _filter = new ContainsCommandMessageFilter();
+        }
+
+        [Test]
+        public void Filter_MessageDoesNotContainCommand_ShouldReturnFalse()
+        {
+            var message = new Message();
+
+            var actual = _filter.Filter(message);
+
+            Assert.False(actual);
+        }
+
+        [Test]
+        public void Filter_MessageContainsCommand_ShouldReturnTrue()
+        {
+            var message = new Message
+            {
+                Entities = new MessageEntity[]
+                {
+                    new MessageEntity { Type = MessageEntityType.BotCommand }
+                }
+            };
+
+            var actual = _filter.Filter(message);
+
+            Assert.True(actual);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/Factory/MessageFilterFactoryTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/Factory/MessageFilterFactoryTests.cs
@@ -1,0 +1,62 @@
+﻿namespace RocketNotify.TelegramBot.Tests.Filtration.Factory
+{
+    using System;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Filtration;
+    using RocketNotify.TelegramBot.Filtration.Factory;
+
+    [TestFixture]
+    public class MessageFilterFactoryTests
+    {
+        private Mock<IChainedMessageFilter> _firstFilter;
+
+        private Mock<IChainedMessageFilter> _secondFilter;
+
+        private Mock<IChainedMessageFilter> _thirdFilter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _firstFilter = new Mock<IChainedMessageFilter>();
+            _secondFilter = new Mock<IChainedMessageFilter>();
+            _thirdFilter = new Mock<IChainedMessageFilter>();
+        }
+
+        [Test]
+        public void GetFilter_NoFilters_ShouldThrowException()
+        {
+            var factory = new MessageFilterFactory(() => Array.Empty<IChainedMessageFilter>());
+
+            Assert.Throws<ArgumentException>(() => factory.GetFilter());
+        }
+
+        [Test]
+        public void GetFilter_HasOneFilter_ShouldReturnOneFilter()
+        {
+            var factory = new MessageFilterFactory(() => new[] { _firstFilter.Object });
+
+            var actual = factory.GetFilter();
+
+            Assert.AreEqual(_firstFilter.Object, actual);
+            _firstFilter.Verify(x => x.SetNextFilter(It.IsAny<IMessageFilter>()), Times.Never);
+        }
+
+        [Test]
+        public void GetFilter_HasFilters_ShouldSetUpChainAndReturn()
+        {
+            var factory = new MessageFilterFactory(
+                () => new[] { _firstFilter.Object, _secondFilter.Object, _thirdFilter.Object });
+
+            var actual = factory.GetFilter();
+
+            Assert.AreEqual(_firstFilter.Object, actual);
+            _firstFilter.Verify(x => x.SetNextFilter(_secondFilter.Object), Times.Once);
+            _secondFilter.Verify(x => x.SetNextFilter(_thirdFilter.Object), Times.Once);
+            _thirdFilter.Verify(x => x.SetNextFilter(It.IsAny<IMessageFilter>()), Times.Never);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/MessageTypeMessageFilterTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/MessageTypeMessageFilterTests.cs
@@ -1,0 +1,50 @@
+﻿namespace RocketNotify.TelegramBot.Tests.Filtration
+{
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Filtration;
+
+    using Telegram.Bot.Types;
+
+    [TestFixture]
+    public class MessageTypeMessageFilterTests
+    {
+        private Mock<IMessageFilter> _nextFilter;
+
+        private MessageTypeMessageFilter _filter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _nextFilter = new Mock<IMessageFilter>();
+            _nextFilter.Setup(x => x.Filter(It.IsAny<Message>())).Returns(true);
+
+            _filter = new MessageTypeMessageFilter();
+            _filter.SetNextFilter(_nextFilter.Object);
+        }
+
+        [Test]
+        public void Filter_VideoMessage_ShouldReturnFalse()
+        {
+            var message = new Message { Video = new Video() };
+
+            var actual = _filter.Filter(message);
+
+            Assert.False(actual);
+            _nextFilter.Verify(x => x.Filter(It.IsAny<Message>()), Times.Never);
+        }
+
+        [Test]
+        public void Filter_TextMessage_ShouldInvokeNextFilter()
+        {
+            var message = new Message { Text = "test" };
+
+            var actual = _filter.Filter(message);
+
+            Assert.True(actual);
+            _nextFilter.Verify(x => x.Filter(It.IsAny<Message>()), Times.Once);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/RelevantMessageFilterTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Filtration/RelevantMessageFilterTests.cs
@@ -1,0 +1,59 @@
+﻿namespace RocketNotify.TelegramBot.Tests.Filtration
+{
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Filtration;
+    using RocketNotify.TelegramBot.MessageProcessing;
+    using RocketNotify.TelegramBot.MessageProcessing.Model;
+
+    using Telegram.Bot.Types;
+
+    [TestFixture]
+    public class RelevantMessageFilterTests
+    {
+        private Mock<IMessageProcessorStorage> _messageProcessorStorage;
+
+        private Mock<IMessageFilter> _nextFilter;
+
+        private RelevantMessageFilter _filter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _messageProcessorStorage = new Mock<IMessageProcessorStorage>();
+
+            _nextFilter = new Mock<IMessageFilter>();
+            _nextFilter.Setup(x => x.Filter(It.IsAny<Message>())).Returns(true);
+
+            _filter = new RelevantMessageFilter(_messageProcessorStorage.Object);
+            _filter.SetNextFilter(_nextFilter.Object);
+        }
+
+        [Test]
+        public void Filter_MessageIsRelevant_ShouldReturnTrue()
+        {
+            var message = new Message { Chat = new Chat() };
+            _messageProcessorStorage.Setup(x => x.IsRelevantToAny(It.IsAny<BotMessage>())).Returns(true);
+
+            var actual = _filter.Filter(message);
+
+            Assert.True(actual);
+            _messageProcessorStorage.Verify(x => x.IsRelevantToAny(It.IsAny<BotMessage>()), Times.Once);
+            _nextFilter.Verify(x => x.Filter(It.IsAny<Message>()), Times.Never);
+        }
+
+        [Test]
+        public void Filter_MessageNotRelevant_ShouldInvokeNextFilter()
+        {
+            var message = new Message { Chat = new Chat() };
+
+            var actual = _filter.Filter(message);
+
+            Assert.True(actual);
+            _messageProcessorStorage.Verify(x => x.IsRelevantToAny(It.IsAny<BotMessage>()), Times.Once);
+            _nextFilter.Verify(x => x.Filter(message), Times.Once);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Help/HelpCommandProcessorTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Help/HelpCommandProcessorTests.cs
@@ -1,0 +1,67 @@
+﻿namespace RocketNotify.TelegramBot.Tests.MessageProcessing.Help
+{
+    using System.Threading.Tasks;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Client;
+    using RocketNotify.TelegramBot.MessageProcessing.Commands;
+    using RocketNotify.TelegramBot.MessageProcessing.Help;
+    using RocketNotify.TelegramBot.MessageProcessing.Model;
+
+    [TestFixture]
+    public class HelpCommandProcessorTests
+    {
+        private Mock<ITelegramMessageSender> _responder;
+
+        private Mock<ICommandInfoAggregator> _commandInfoAggragator;
+
+        private HelpCommandProcessor _processor;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _responder = new Mock<ITelegramMessageSender>();
+            _commandInfoAggragator = new Mock<ICommandInfoAggregator>();
+            _processor = new HelpCommandProcessor(_commandInfoAggragator.Object, _responder.Object);
+        }
+
+        [TestCase("")]
+        [TestCase("Test text")]
+        [TestCase("Test text with a 'Help' word in it")]
+        public void IsRelevant_DoesNotContainCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.False(actual);
+        }
+
+        [TestCase("/help")]
+        [TestCase("Test text with a /Help command in it")]
+        [TestCase("/help@bot_name")]
+        [TestCase("/help @bot_name")]
+        [TestCase("@bot_name /help")]
+        public void IsRelevant_ContainsCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.True(actual);
+        }
+
+        [Test]
+        public async Task ProcessAsync_ShouldSendMessage()
+        {
+            _commandInfoAggragator.Setup(x => x.GetDescriptions()).Returns(new[] { new CommandDescription("/test", "test") });
+
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/help" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/MessageProcessorInvokerTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/MessageProcessorInvokerTests.cs
@@ -1,0 +1,119 @@
+﻿namespace RocketNotify.TelegramBot.Tests.MessageProcessing
+{
+    using System.Threading.Tasks;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.MessageProcessing;
+    using RocketNotify.TelegramBot.MessageProcessing.Model;
+    using RocketNotify.TelegramBot.MessageProcessing.Unsupported;
+
+    [TestFixture]
+    public class MessageProcessorInvokerTests
+    {
+        private Mock<IMessageProcessor> _firstProcessor;
+
+        private Mock<IMessageProcessor> _secondProcessor;
+
+        private Mock<IUnsupportedCommandProcessor> _unsupportedProcessor;
+
+        private MessageProcessorStorage _processorStorage;
+
+        private MessageProcessorFactory _processorFactory;
+
+        private MessageProcessorInvoker _processorInvoker;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _firstProcessor = new Mock<IMessageProcessor>();
+            _secondProcessor = new Mock<IMessageProcessor>();
+            _unsupportedProcessor = new Mock<IUnsupportedCommandProcessor>();
+
+            _processorStorage = new MessageProcessorStorage();
+            _processorFactory = new MessageProcessorFactory(() => new[] { _firstProcessor.Object, _secondProcessor.Object }, () => _unsupportedProcessor.Object);
+            _processorInvoker = new MessageProcessorInvoker(_processorStorage, _processorFactory);
+        }
+
+        [Test]
+        public async Task InvokeAsync_RelevantToFirstProcessor_ShouldInvokeFirstProcessor()
+        {
+            _firstProcessor.Setup(x => x.ProcessAsync(It.IsAny<BotMessage>())).ReturnsAsync(ProcessResult.Final());
+            _firstProcessor.Setup(x => x.IsRelevant(It.IsAny<BotMessage>())).Returns(true);
+
+            var message = new BotMessage();
+            await _processorInvoker.InvokeAsync(message).ConfigureAwait(false);
+
+            Assert.AreEqual(0, _processorStorage.Count);
+            _firstProcessor.Verify(x => x.ProcessAsync(message), Times.Once);
+            _firstProcessor.Verify(x => x.IsRelevant(message), Times.Once);
+            _secondProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+            _secondProcessor.Verify(x => x.IsRelevant(message), Times.Never);
+            _unsupportedProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+        }
+
+        [Test]
+        public async Task InvokeAsync_NotRelevantToAny_ShouldInvokeUnsupportedProcessor()
+        {
+            _unsupportedProcessor.Setup(x => x.ProcessAsync(It.IsAny<BotMessage>())).ReturnsAsync(ProcessResult.Final());
+
+            var message = new BotMessage();
+            await _processorInvoker.InvokeAsync(message).ConfigureAwait(false);
+
+            Assert.AreEqual(0, _processorStorage.Count);
+            _firstProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+            _firstProcessor.Verify(x => x.IsRelevant(message), Times.Once);
+            _secondProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+            _secondProcessor.Verify(x => x.IsRelevant(message), Times.Once);
+            _unsupportedProcessor.Verify(x => x.ProcessAsync(message), Times.Once);
+        }
+
+        [Test]
+        public async Task InvokeAsync_RelevantToExistingProcessor_ShouldInvokeExistingProcessor()
+        {
+            _secondProcessor.Setup(x => x.ProcessAsync(It.IsAny<BotMessage>())).ReturnsAsync(ProcessResult.Final());
+            _secondProcessor.Setup(x => x.IsRelevant(It.IsAny<BotMessage>())).Returns(true);
+
+            var message = new BotMessage();
+            _processorStorage.StoreProcessor(_secondProcessor.Object);
+            Assert.AreEqual(1, _processorStorage.Count);
+            await _processorInvoker.InvokeAsync(message).ConfigureAwait(false);
+
+            Assert.AreEqual(0, _processorStorage.Count);
+            _firstProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+            _firstProcessor.Verify(x => x.IsRelevant(message), Times.Never);
+            _secondProcessor.Verify(x => x.ProcessAsync(message), Times.Once);
+            _secondProcessor.Verify(x => x.IsRelevant(message), Times.Once);
+            _unsupportedProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+        }
+
+        [Test]
+        public async Task InvokeAsync_ProcessorAwaitsAnotherMessage_ShouldInvokeProcessorTwice()
+        {
+            var invokeCount = 0;
+            _secondProcessor.Setup(x => x.ProcessAsync(It.IsAny<BotMessage>())).ReturnsAsync(() => ++invokeCount < 2 ? new ProcessResult() : ProcessResult.Final());
+            _secondProcessor.Setup(x => x.IsRelevant(It.IsAny<BotMessage>())).Returns(true);
+
+            var message = new BotMessage();
+            await _processorInvoker.InvokeAsync(message).ConfigureAwait(false);
+
+            Assert.AreEqual(1, _processorStorage.Count);
+            _firstProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+            _firstProcessor.Verify(x => x.IsRelevant(message), Times.Once);
+            _secondProcessor.Verify(x => x.ProcessAsync(message), Times.Once);
+            _secondProcessor.Verify(x => x.IsRelevant(message), Times.Once);
+            _unsupportedProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+
+            await _processorInvoker.InvokeAsync(message).ConfigureAwait(false);
+
+            Assert.AreEqual(0, _processorStorage.Count);
+            _firstProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+            _firstProcessor.Verify(x => x.IsRelevant(message), Times.Once);
+            _secondProcessor.Verify(x => x.ProcessAsync(message), Times.Exactly(2));
+            _secondProcessor.Verify(x => x.IsRelevant(message), Times.Exactly(2));
+            _unsupportedProcessor.Verify(x => x.ProcessAsync(message), Times.Never);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Model/MessageConverterTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Model/MessageConverterTests.cs
@@ -1,0 +1,68 @@
+﻿namespace RocketNotify.TelegramBot.Tests.MessageProcessing.Model
+{
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.MessageProcessing.Model;
+
+    using Telegram.Bot.Types;
+
+    [TestFixture]
+    public class MessageConverterTests
+    {
+        [Test]
+        public void Convert_RegularMessageFromGroup_ShouldConvert()
+        {
+            var message = new Message
+            {
+                MessageId = 123,
+                Chat = new Chat { Title = "TestChat" },
+                Text = "Test Message Text"
+            };
+
+            var converted = MessageConverter.Convert(message);
+
+            Assert.NotNull(converted);
+            Assert.AreEqual(message.MessageId, converted.MessageId);
+            Assert.AreEqual(message.Text, converted.Text);
+            Assert.AreEqual(message.Chat.Title, converted.Sender.Name);
+        }
+
+        [Test]
+        public void Convert_RegularMessageFromUser_ShouldConvert()
+        {
+            var message = new Message
+            {
+                MessageId = 123,
+                Chat = new Chat { FirstName = "TestUserName" },
+                Text = "Test Message Text"
+            };
+
+            var converted = MessageConverter.Convert(message);
+
+            Assert.NotNull(converted);
+            Assert.AreEqual(message.MessageId, converted.MessageId);
+            Assert.AreEqual(message.Text, converted.Text);
+            Assert.AreEqual(message.Chat.FirstName, converted.Sender.Name);
+        }
+
+        [Test]
+        public void Convert_ReplyMessage_ShouldConvertWithReply()
+        {
+            var message = new Message
+            {
+                MessageId = 123,
+                Chat = new Chat { FirstName = "TestUserName" },
+                Text = "Test Message Text",
+                ReplyToMessage = new Message { MessageId = 122 }
+            };
+
+            var converted = MessageConverter.Convert(message);
+
+            Assert.NotNull(converted);
+            Assert.AreEqual(message.MessageId, converted.MessageId);
+            Assert.AreEqual(message.Text, converted.Text);
+            Assert.AreEqual(message.Chat.FirstName, converted.Sender.Name);
+            Assert.AreEqual(message.ReplyToMessage.MessageId, converted.ReplyInfo.SourceMessageId);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Start/StartCommandProcessorTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Start/StartCommandProcessorTests.cs
@@ -1,0 +1,61 @@
+﻿namespace RocketNotify.TelegramBot.Tests.MessageProcessing.Start
+{
+    using System.Threading.Tasks;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Client;
+    using RocketNotify.TelegramBot.MessageProcessing.Model;
+    using RocketNotify.TelegramBot.MessageProcessing.Start;
+
+    [TestFixture]
+    public class StartCommandProcessorTests
+    {
+        private Mock<ITelegramMessageSender> _responder;
+
+        private StartCommandProcessor _processor;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _responder = new Mock<ITelegramMessageSender>();
+            _processor = new StartCommandProcessor(_responder.Object);
+        }
+
+        [TestCase("")]
+        [TestCase("Test text")]
+        [TestCase("Test text with a 'Start' word in it")]
+        public void IsRelevant_DoesNotContainCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.False(actual);
+        }
+
+        [TestCase("/start")]
+        [TestCase("Test text with a /Start command in it")]
+        [TestCase("/start@bot_name")]
+        [TestCase("/start @bot_name")]
+        [TestCase("@bot_name /start")]
+        public void IsRelevant_ContainsCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.True(actual);
+        }
+
+        [Test]
+        public async Task ProcessAsync_ShouldSendMessage()
+        {
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/start" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Subscribe/SubscribeCommandProcessorTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Subscribe/SubscribeCommandProcessorTests.cs
@@ -1,0 +1,233 @@
+﻿namespace RocketNotify.TelegramBot.Tests.MessageProcessing.Subscribe
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.Subscription.Exceptions;
+    using RocketNotify.Subscription.Services;
+    using RocketNotify.TelegramBot.Client;
+    using RocketNotify.TelegramBot.MessageProcessing.Model;
+    using RocketNotify.TelegramBot.MessageProcessing.Subscribe;
+
+    using Telegram.Bot.Types.ReplyMarkups;
+
+    [TestFixture]
+    public class SubscribeCommandProcessorTests
+    {
+        private Mock<ISubscriptionService> _subscriptionService;
+
+        private SubscriptionCompleteState _completedState;
+
+        private VerifySubscriptionState _verifyState;
+
+        private InitialSubscribeState _initialState;
+
+        private Mock<ITelegramMessageSender> _responder;
+
+        private SubscribeCommandProcessor _processor;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _subscriptionService = new Mock<ISubscriptionService>();
+
+            _completedState = new SubscriptionCompleteState();
+            _verifyState = new VerifySubscriptionState(_subscriptionService.Object, () => _completedState);
+            _initialState = new InitialSubscribeState(_subscriptionService.Object, () => _verifyState, () => _completedState);
+
+            _responder = new Mock<ITelegramMessageSender>();
+            _processor = new SubscribeCommandProcessor(_responder.Object, () => _initialState);
+        }
+
+        [TestCase("")]
+        [TestCase("Test text")]
+        [TestCase("Test text with a 'Unsubscribe' word in it")]
+        [TestCase("/sub")]
+        public void IsRelevant_InitialState_DoesNotContainCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.False(actual);
+        }
+
+        [TestCase("/Subscribe")]
+        [TestCase("Test text with a /subscribe command in it")]
+        [TestCase("/subscribe@bot_name")]
+        [TestCase("/subscribe @bot_name")]
+        [TestCase("@bot_name /subscribe")]
+        public void IsRelevant_InitialState_ContainsCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.True(actual);
+        }
+
+        [Test]
+        public void IsRelevant_VerifyState_DoesNotContainReply_ShouldReturnFalse()
+        {
+            var botResponse = new BotMessage { MessageId = 1 };
+
+            _processor.Context.LastResponse = botResponse;
+            _processor.ChangeCurrentState(_verifyState);
+
+            var message = new BotMessage { Text = "secret" };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.False(actual);
+        }
+
+        [Test]
+        public void IsRelevant_VerifyState_ContainsReply_ShouldReturnTrue()
+        {
+            var botResponse = new BotMessage { MessageId = 1 };
+
+            _processor.Context.LastResponse = botResponse;
+            _processor.ChangeCurrentState(_verifyState);
+
+            var message = new BotMessage { Text = "secret", ReplyInfo = new MessageReply { SourceMessageId = botResponse.MessageId } };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.True(actual);
+        }
+
+        [Test]
+        public void IsRelevant_VerifyState_ContextIsEmpty_ShouldThrowException()
+        {
+            _processor.ChangeCurrentState(_verifyState);
+
+            var message = new BotMessage { Text = "secret" };
+            Assert.Throws<InvalidOperationException>(() => _processor.IsRelevant(message));
+        }
+
+        [Test]
+        public void IsRelevant_CompletedState_ShouldReturnFalse()
+        {
+            _processor.ChangeCurrentState(_completedState);
+
+            var message = new BotMessage { Text = "some_text" };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.False(actual);
+        }
+
+        [Test]
+        public async Task ProcessAsync_InitialState_NoNeedForVerification_ShouldSubscribeAndRespond()
+        {
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/subscribe" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            Assert.AreEqual(_completedState, _processor.CurrentState);
+            _subscriptionService.Verify(x => x.AddSubscriptionAsync(message.Sender.Id, string.Empty), Times.Once);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public async Task ProcessAsync_InitialState_NoNeedForVerification_ErrorDuringSubscription_ShouldSendResponse()
+        {
+            _subscriptionService.Setup(x => x.CheckSubscriptionKeyNeeded()).Returns(false);
+            _subscriptionService.Setup(x => x.AddSubscriptionAsync(It.IsAny<long>(), It.IsAny<string>())).ThrowsAsync(new SubscriberAlreadyExistsException("test"));
+
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/subscribe" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            Assert.AreEqual(_completedState, _processor.CurrentState);
+            _subscriptionService.Verify(x => x.AddSubscriptionAsync(message.Sender.Id, string.Empty), Times.Once);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public void ProcessAsync_InitialState_NoNeedForVerification_UnexpectedError_ShouldThrow()
+        {
+            _subscriptionService.Setup(x => x.CheckSubscriptionKeyNeeded()).Returns(false);
+            _subscriptionService.Setup(x => x.AddSubscriptionAsync(It.IsAny<long>(), It.IsAny<string>())).ThrowsAsync(new InvalidOperationException());
+
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/subscribe" };
+            Assert.ThrowsAsync<InvalidOperationException>(() => _processor.ProcessAsync(message));
+
+            _subscriptionService.Verify(x => x.AddSubscriptionAsync(message.Sender.Id, string.Empty), Times.Once);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public async Task ProcessAsync_InitialState_VerificationNeeded_ShouldRequestVerificationKey()
+        {
+            _subscriptionService.Setup(x => x.CheckSubscriptionKeyNeeded()).Returns(true);
+
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/subscribe" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.False(result.IsFinal);
+            Assert.AreEqual(_verifyState, _processor.CurrentState);
+            Assert.AreEqual(message, _processor.Context.LastMessage);
+            _subscriptionService.Verify(x => x.AddSubscriptionAsync(message.Sender.Id, string.Empty), Times.Never);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>(), It.IsAny<IReplyMarkup>()), Times.Once);
+        }
+
+        [Test]
+        public async Task ProcessAsync_VerifyState_VerificationKeyReceived_ShouldSubscribeAndRespond()
+        {
+            _subscriptionService.Setup(x => x.CheckSubscriptionKeyNeeded()).Returns(true);
+
+            _processor.ChangeCurrentState(_verifyState);
+            var message = new BotMessage
+            {
+                Sender = new MessageSender { Id = 2, Name = "User" },
+                Text = "secret",
+                ReplyInfo = new MessageReply { SourceMessageId = 1 }
+            };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            Assert.AreEqual(_completedState, _processor.CurrentState);
+            _subscriptionService.Verify(x => x.AddSubscriptionAsync(message.Sender.Id, message.Text), Times.Once);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public async Task ProcessAsync_VerifyState_ErrorDuringSubscription_ShouldRespond()
+        {
+            _subscriptionService.Setup(x => x.CheckSubscriptionKeyNeeded()).Returns(true);
+            _subscriptionService.Setup(x => x.AddSubscriptionAsync(It.IsAny<long>(), It.IsAny<string>())).ThrowsAsync(new SubscriptionNotAllowedException("invalid key"));
+
+            _processor.ChangeCurrentState(_verifyState);
+            var message = new BotMessage { Sender = new MessageSender { Id = 2, Name = "User" }, Text = "secret" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            Assert.AreEqual(_completedState, _processor.CurrentState);
+            _subscriptionService.Verify(x => x.AddSubscriptionAsync(message.Sender.Id, message.Text), Times.Once);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public void ProcessAsync_VerifyState_UnexpectedError_ShouldThrow()
+        {
+            _subscriptionService.Setup(x => x.CheckSubscriptionKeyNeeded()).Returns(true);
+            _subscriptionService.Setup(x => x.AddSubscriptionAsync(It.IsAny<long>(), It.IsAny<string>())).ThrowsAsync(new InvalidOperationException());
+
+            _processor.ChangeCurrentState(_verifyState);
+            var message = new BotMessage { Sender = new MessageSender { Id = 2, Name = "User" }, Text = "secret" };
+            Assert.ThrowsAsync<InvalidOperationException>(() => _processor.ProcessAsync(message));
+
+            _subscriptionService.Verify(x => x.AddSubscriptionAsync(message.Sender.Id, message.Text), Times.Once);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void ProcessAsync_CompletedState_ShouldThrowException()
+        {
+            _processor.ChangeCurrentState(_completedState);
+
+            var message = new BotMessage();
+            Assert.ThrowsAsync<InvalidOperationException>(() => _processor.ProcessAsync(message));
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Unsubscribe/UnsubscribeCommandProcessorTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Unsubscribe/UnsubscribeCommandProcessorTests.cs
@@ -1,0 +1,103 @@
+﻿namespace RocketNotify.TelegramBot.Tests.MessageProcessing.Unsubscribe
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.Subscription.Exceptions;
+    using RocketNotify.Subscription.Services;
+    using RocketNotify.TelegramBot.Client;
+    using RocketNotify.TelegramBot.MessageProcessing.Model;
+    using RocketNotify.TelegramBot.MessageProcessing.Unsubscribe;
+
+    [TestFixture]
+    public class UnsubscribeCommandProcessorTests
+    {
+        private Mock<ISubscriptionService> _subscriptionService;
+
+        private Mock<ITelegramMessageSender> _responder;
+
+        private UnsubscribeCommandProcessor _processor;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _subscriptionService = new Mock<ISubscriptionService>();
+            _responder = new Mock<ITelegramMessageSender>();
+            _processor = new UnsubscribeCommandProcessor(_subscriptionService.Object, _responder.Object);
+        }
+
+        [TestCase("")]
+        [TestCase("Test text")]
+        [TestCase("Test text with a 'Unsubscribe' word in it")]
+        [TestCase("/unsub")]
+        public void IsRelevant_DoesNotContainCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.False(actual);
+        }
+
+        [TestCase("/unsubscribe")]
+        [TestCase("Test text with a /Unsubscribe command in it")]
+        [TestCase("/unsubscribe@bot_name")]
+        [TestCase("/unsubscribe @bot_name")]
+        [TestCase("@bot_name /unsubscribe")]
+        public void IsRelevant_ContainsCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.True(actual);
+        }
+
+        [Test]
+        public async Task ProcessAsync_Unsubscribed_ShouldSendMessage()
+        {
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/unsubscribe" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public async Task ProcessAsync_SubscriberNotFound_ShouldSendMessage()
+        {
+            _subscriptionService.Setup(x => x.RemoveSubscriptionAsync(It.IsAny<long>())).ThrowsAsync(new SubscriberNotFoundException("test"));
+
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/unsubscribe" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public async Task ProcessAsync_SubscriberOperationExceptionOccurred_ShouldSendMessage()
+        {
+            _subscriptionService.Setup(x => x.RemoveSubscriptionAsync(It.IsAny<long>())).ThrowsAsync(new SubscriberOperationException("test"));
+
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/unsubscribe" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public void ProcessAsync_UnexpectedException_ShouldThrow()
+        {
+            _subscriptionService.Setup(x => x.RemoveSubscriptionAsync(It.IsAny<long>())).ThrowsAsync(new InvalidOperationException("test"));
+
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/unsubscribe" };
+            Assert.ThrowsAsync<InvalidOperationException>(() => _processor.ProcessAsync(message));
+
+            _responder.Verify(x => x.SendMessageAsync(It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Unsupported/UnsupportedCommandProcessorTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/MessageProcessing/Unsupported/UnsupportedCommandProcessorTests.cs
@@ -1,0 +1,60 @@
+﻿namespace RocketNotify.TelegramBot.Tests.MessageProcessing.Unsupported
+{
+    using System.Threading.Tasks;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Client;
+    using RocketNotify.TelegramBot.MessageProcessing.Model;
+    using RocketNotify.TelegramBot.MessageProcessing.Unsupported;
+
+    [TestFixture]
+    public class UnsupportedCommandProcessorTests
+    {
+        private Mock<ITelegramMessageSender> _responder;
+
+        private UnsupportedCommandProcessor _processor;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _responder = new Mock<ITelegramMessageSender>();
+            _processor = new UnsupportedCommandProcessor(_responder.Object);
+        }
+
+        [TestCase("")]
+        [TestCase("Test text")]
+        public void IsRelevant_DoesNotContainCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.False(actual);
+        }
+
+        [TestCase("/not_supported_command")]
+        [TestCase("Test text with some /random command in it")]
+        [TestCase("/dunno@bot_name")]
+        [TestCase("/okay @bot_name")]
+        [TestCase("@bot_name /start")]
+        public void IsRelevant_ContainsCommand_ShouldReturnFalse(string text)
+        {
+            var message = new BotMessage { Text = text };
+            var actual = _processor.IsRelevant(message);
+
+            Assert.True(actual);
+        }
+
+        [Test]
+        public async Task ProcessAsync_ShouldSendMessage()
+        {
+            var message = new BotMessage { Sender = new MessageSender { Id = 1, Name = "User" }, Text = "/some_command" };
+            var result = await _processor.ProcessAsync(message).ConfigureAwait(false);
+
+            Assert.True(result.IsFinal);
+            _responder.Verify(x => x.SendMessageAsync(message.Sender.Id, It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Messages/BotMessageHandlerTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Messages/BotMessageHandlerTests.cs
@@ -1,0 +1,85 @@
+﻿namespace RocketNotify.TelegramBot.Tests.Messages
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using Microsoft.Extensions.Logging;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Filtration;
+    using RocketNotify.TelegramBot.Filtration.Factory;
+    using RocketNotify.TelegramBot.MessageProcessing;
+    using RocketNotify.TelegramBot.MessageProcessing.Model;
+    using RocketNotify.TelegramBot.Messages;
+
+    using Telegram.Bot.Types;
+
+    [TestFixture]
+    public class BotMessageHandlerTests
+    {
+        private Mock<IMessageFilter> _messageFilter;
+
+        private Mock<IMessageProcessorInvoker> _messageProcessorInvoker;
+
+        private Mock<ILogger<BotMessageHandler>> _logger;
+
+        private BotMessageHandler _handler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _messageFilter = new Mock<IMessageFilter>();
+            var messageFilterFactory = new Mock<IMessageFilterFactory>();
+            messageFilterFactory.Setup(x => x.GetFilter()).Returns(_messageFilter.Object);
+
+            _messageProcessorInvoker = new Mock<IMessageProcessorInvoker>();
+            _logger = new Mock<ILogger<BotMessageHandler>>();
+
+            _handler = new BotMessageHandler(messageFilterFactory.Object, _messageProcessorInvoker.Object, _logger.Object);
+        }
+
+        [Test]
+        public async Task HandleAsync_MessageFilteredOut_ShouldReturn()
+        {
+            var message = CreateTestMessage();
+            await _handler.HandleAsync(message).ConfigureAwait(false);
+
+            _messageProcessorInvoker.Verify(x => x.InvokeAsync(It.IsAny<BotMessage>()), Times.Never);
+        }
+
+        [Test]
+        public async Task HandleAsync_ExceptionDuringFiltration_ShouldReturn()
+        {
+            _messageFilter.Setup(x => x.Filter(It.IsAny<Message>())).Throws<InvalidOperationException>();
+
+            var message = CreateTestMessage();
+            await _handler.HandleAsync(message).ConfigureAwait(false);
+
+            _messageProcessorInvoker.Verify(x => x.InvokeAsync(It.IsAny<BotMessage>()), Times.Never);
+        }
+
+        [Test]
+        public async Task HandleAsync_MessagePassedFilters_ShouldProcess()
+        {
+            _messageFilter.Setup(x => x.Filter(It.IsAny<Message>())).Returns(true);
+
+            var message = CreateTestMessage();
+            await _handler.HandleAsync(message).ConfigureAwait(false);
+
+            _messageProcessorInvoker.Verify(x => x.InvokeAsync(It.IsAny<BotMessage>()), Times.Once);
+        }
+
+        private Message CreateTestMessage()
+        {
+            return new Message
+            {
+                From = new User { Username = "User" },
+                Chat = new Chat { Title = "Chat", FirstName = "Chat" },
+                Text = "Text"
+            };
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Messages/MessageExtensionsTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Messages/MessageExtensionsTests.cs
@@ -1,0 +1,57 @@
+﻿namespace RocketNotify.TelegramBot.Tests.Messages
+{
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Messages;
+
+    using Telegram.Bot.Types;
+    using Telegram.Bot.Types.Enums;
+
+    [TestFixture]
+    public class MessageExtensionsTests
+    {
+        [Test]
+        public void GetEntities_NoEntities_ShouldReturnEmptyArray()
+        {
+            var message = new Message();
+
+            var actual = message.GetEntities();
+
+            Assert.NotNull(actual);
+            Assert.IsEmpty(actual);
+        }
+
+        [Test]
+        public void GetEntities_HasEntities_ShouldReturnArray()
+        {
+            var message = new Message
+            {
+                Text = "/start @bot_name http://test.com 555-258-66-77",
+                Entities = new MessageEntity[]
+                {
+                    new MessageEntity { Type = MessageEntityType.BotCommand, Offset = 0, Length = 6 },
+                    new MessageEntity { Type = MessageEntityType.Mention, Offset = 7, Length = 9 },
+                    new MessageEntity { Type = MessageEntityType.Url, Offset = 17, Length = 15 },
+                    new MessageEntity { Type = MessageEntityType.PhoneNumber, Offset = 33, Length = 13 }
+                }
+            };
+
+            var expected = new (MessageEntityType Type, string Value)[]
+            {
+                (MessageEntityType.BotCommand, "/start"),
+                (MessageEntityType.Mention, "@bot_name"),
+                (MessageEntityType.Url, "http://test.com"),
+                (MessageEntityType.PhoneNumber, "555-258-66-77"),
+            };
+
+            var actual = message.GetEntities();
+
+            Assert.AreEqual(expected.Length, actual.Length);
+            for (var i = 0; i < expected.Length; i++)
+            {
+                Assert.AreEqual(expected[i].Type, actual[i].Type);
+                Assert.AreEqual(expected[i].Value, actual[i].Value);
+            }
+        }
+    }
+}

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Settings/BotSettingsProviderTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Settings/BotSettingsProviderTests.cs
@@ -1,0 +1,74 @@
+﻿namespace RocketNotify.TelegramBot.Tests.Settings
+{
+    using Microsoft.Extensions.Configuration;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using RocketNotify.TelegramBot.Settings;
+
+    [TestFixture]
+    public class BotSettingsProviderTests
+    {
+        private Mock<IConfiguration> _configurationMock;
+
+        private BotSettingsProvider _settingsProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _configurationMock = new Mock<IConfiguration>();
+            _settingsProvider = new BotSettingsProvider(_configurationMock.Object);
+        }
+
+        [Test]
+        public void GetBotUserName_NoSection_ShouldReturnStringEmpty()
+        {
+            var actual = _settingsProvider.GetBotUserName();
+
+            Assert.AreEqual(string.Empty, actual);
+        }
+
+        [Test]
+        public void GetBotUserName_StringEmpty_ShouldReturnStringEmpty()
+        {
+            SetUpConfiguration("Telegram", "BotName", string.Empty);
+
+            var actual = _settingsProvider.GetBotUserName();
+
+            Assert.AreEqual(string.Empty, actual);
+        }
+
+        [Test]
+        public void GetBotUserName_BotWithAtSign_ShouldReturnAsIs()
+        {
+            var expected = "@testName_bot";
+            SetUpConfiguration("Telegram", "BotName", expected);
+
+            var actual = _settingsProvider.GetBotUserName();
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void GetBotUserName_BotWithoutAtSign_ShouldAddPrefixAndReturn()
+        {
+            var botName = "testName_bot";
+            var expected = $"@{botName}";
+            SetUpConfiguration("Telegram", "BotName", botName);
+
+            var actual = _settingsProvider.GetBotUserName();
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        private void SetUpConfiguration(string sectionName, string key, string value)
+        {
+            var sectionMock = new Mock<IConfigurationSection>();
+            sectionMock.Setup(x => x[key]).Returns(value);
+
+            _configurationMock.Setup(x => x.GetSection(sectionName)).Returns(sectionMock.Object);
+        }
+    }
+}


### PR DESCRIPTION
Fixed some unit tests.
Added new unit tests for message filtration and message processing modules.
Several changes to the NotifierBackgroundService to make it safer: it won't break if a single exception is thrown by the Rocket.Chat client or the Telegram client. Instead, it keeps track of errors, and when the number of them reaches the default value of 10, execution will stop.

Also, extended logging of exceptions.