### PR TITLE
Some error tolerance

### DIFF
--- a/Source/RocketNotify.ChatClient/Exceptions/RocketChatApiException.cs
+++ b/Source/RocketNotify.ChatClient/Exceptions/RocketChatApiException.cs
@@ -15,5 +15,14 @@
             : base(message)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RocketChatApiException"/> class.
+        /// </summary>
+        /// <param name="innerException">Source exception instance.</param>
+        public RocketChatApiException(Exception innerException)
+            : base(innerException.Message, innerException)
+        {
+        }
     }
 }

--- a/Source/Tests/RocketNotify.ChatClient.Tests/RocketChatClientTests.cs
+++ b/Source/Tests/RocketNotify.ChatClient.Tests/RocketChatClientTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace RocketNotify.ChatClient.Tests
 {
     using System;
+    using System.Net.Http;
+    using System.Text.Json;
     using System.Threading.Tasks;
 
     using Moq;
@@ -9,6 +11,7 @@
 
     using RocketNotify.ChatClient.ApiClient;
     using RocketNotify.ChatClient.Dto.Messages;
+    using RocketNotify.ChatClient.Exceptions;
     using RocketNotify.ChatClient.Settings;
 
     [TestFixture]
@@ -104,6 +107,20 @@
             var actual = await _rocketChatClient.GetLastMessageTimeStampAsync().ConfigureAwait(false);
 
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void GetLastMessageTimeStampAsync_ClientThrowsHttpRequestException_ShouldRethrowRocketChatApiClientException()
+        {
+            _apiClientMock.Setup(x => x.GetLastMessageInGroupAsync(It.IsAny<string>())).Throws<HttpRequestException>();
+            Assert.ThrowsAsync<RocketChatApiException>(() => _rocketChatClient.GetLastMessageTimeStampAsync());
+        }
+
+        [Test]
+        public void GetLastMessageTimeStampAsync_ClientThrowsJsonException_ShouldRethrowRocketChatApiClientException()
+        {
+            _apiClientMock.Setup(x => x.GetLastMessageInGroupAsync(It.IsAny<string>())).Throws<JsonException>();
+            Assert.ThrowsAsync<RocketChatApiException>(() => _rocketChatClient.GetLastMessageTimeStampAsync());
         }
     }
 }

--- a/Source/Tests/RocketNotify.TelegramBot.Tests/Client/TelegramBotPollingClientTests.cs
+++ b/Source/Tests/RocketNotify.TelegramBot.Tests/Client/TelegramBotPollingClientTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace RocketNotify.TelegramBot.Tests.Client
 {
     using System;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -13,6 +14,7 @@
     using RocketNotify.TelegramBot.Messages;
 
     using Telegram.Bot;
+    using Telegram.Bot.Exceptions;
     using Telegram.Bot.Types;
     using Telegram.Bot.Types.Enums;
     using Telegram.Bot.Types.ReplyMarkups;
@@ -87,6 +89,15 @@
         public void SendMessageAsync_NoClient_ShouldThrowException()
         {
             Assert.ThrowsAsync<InvalidOperationException>(() => _client.SendMessageAsync(123456, string.Empty));
+        }
+
+        [Test]
+        public async Task SendMessageAsync_BotClientThrowsException_ShouldRethrowApiRequestException()
+        {
+            await _client.InitializeAsync().ConfigureAwait(false);
+
+            _botClientMock.Setup(x => x.SendTextMessageAsync(It.IsAny<ChatId>(), It.IsAny<string>(), It.IsAny<ParseMode>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<IReplyMarkup>(), It.IsAny<CancellationToken>())).Throws<HttpRequestException>();
+            Assert.ThrowsAsync<ApiRequestException>(() => _client.SendMessageAsync(123456, string.Empty));
         }
 
         [Test]


### PR DESCRIPTION
It looks like clients throw HttpRequestException or JsonException when the connection to the Rocket.Chat or Telegram server fails. When this happens, the background notification service stops working. These errors will now be re-thrown as non-fatal api exceptions and this will give the service some time to retry connecting to the servers. If this fails (as with all non-fatal errors - when the maximum number of errors is exceeded), the service nevertheless terminates.